### PR TITLE
Fix namespace and improve assertEquals assertion

### DIFF
--- a/test/ActionContainerTest.php
+++ b/test/ActionContainerTest.php
@@ -45,6 +45,6 @@ class ActionContainerTest extends TestCase
         ];
         $actionContainer = new ActionContainer($actions);
         $callable = $actionContainer->get(self::SOME_ACTION);
-        $this->assertEquals(self::ACTION_INSTANCE_VALUE, $callable());
+        $this->assertSame(self::ACTION_INSTANCE_VALUE, $callable());
     }
 }

--- a/test/Cli/StartQueueConsumerTest.php
+++ b/test/Cli/StartQueueConsumerTest.php
@@ -19,7 +19,7 @@ class StartQueueConsumerTest extends TestCase
 {
     private $console;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $command = new StartQueueConsumer(
             $this->createMock(QueueConsumerInterface::class),
@@ -52,6 +52,6 @@ class StartQueueConsumerTest extends TestCase
     {
         $output = new BufferedOutput();
         $result = $this->console->run(new ArrayInput(['command' => StartQueueConsumer::NAME, 'queue_name' => 'default']), $output);
-        $this->assertEquals(0, $result);
+        $this->assertSame(0, $result);
     }
 }

--- a/test/Container/LoggerExtensionFactoryTest.php
+++ b/test/Container/LoggerExtensionFactoryTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 
-namespace Antidot\Test\Queue\Container;
+namespace AntidotTest\Queue\Container;
 
 use Antidot\Queue\Container\LoggerExtensionFactory;
 use PHPUnit\Framework\TestCase;

--- a/test/JobPayloadTest.php
+++ b/test/JobPayloadTest.php
@@ -18,14 +18,14 @@ class JobPayloadTest extends TestCase
     public function testIsShouldBeCreatedWithStringMessage(): void
     {
         $jobPayload = JobPayload::create(self::MESSAGE_TYPE, self::MESSAGE_CONTENT);
-        $this->assertEquals(self::MESSAGE_TYPE, $jobPayload->type());
-        $this->assertEquals(self::MESSAGE_CONTENT, $jobPayload->message());
+        $this->assertSame(self::MESSAGE_TYPE, $jobPayload->type());
+        $this->assertSame(self::MESSAGE_CONTENT, $jobPayload->message());
     }
 
     public function testIsShouldBeCreatedWithArrayMessage(): void
     {
         $jobPayload = JobPayload::create(self::MESSAGE_TYPE, self::ARRAY_MESSAGE_CONTENT);
-        $this->assertEquals(self::MESSAGE_TYPE, $jobPayload->type());
+        $this->assertSame(self::MESSAGE_TYPE, $jobPayload->type());
         $this->assertEquals(self::ARRAY_MESSAGE_CONTENT, $jobPayload->message());
     }
 

--- a/test/JobTest.php
+++ b/test/JobTest.php
@@ -21,14 +21,14 @@ class JobTest extends TestCase
     public function testItShouldBeCreatedWithQueueNameMessageTypeAndMessage(): void
     {
         $job = Job::create(self::SOME_QUEUE_NAME, self::MESSAGE_TYPE, self::MESSAGE_CONTENT);
-        $this->assertEquals(self::SOME_QUEUE_NAME, $job->queueName());
-        $this->assertEquals(self::PAYLOAD, $job->payload());
+        $this->assertSame(self::SOME_QUEUE_NAME, $job->queueName());
+        $this->assertSame(self::PAYLOAD, $job->payload());
     }
 
     public function testItShouldBeCreatedWithQueueNameMessageTypeAndArrayMessage(): void
     {
         $job = Job::create(self::SOME_QUEUE_NAME, self::MESSAGE_TYPE, self::MESSAGE_ARRAY_CONTENT);
-        $this->assertEquals(self::SOME_QUEUE_NAME, $job->queueName());
-        $this->assertEquals(self::ARRAY_PAYLOAD, $job->payload());
+        $this->assertSame(self::SOME_QUEUE_NAME, $job->queueName());
+        $this->assertSame(self::ARRAY_PAYLOAD, $job->payload());
     }
 }

--- a/test/MessageProcessorTest.php
+++ b/test/MessageProcessorTest.php
@@ -27,7 +27,7 @@ class MessageProcessorTest extends TestCase
     private $actionContainer;
     private $eventDispatcher;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->context = $this->createMock(Context::class);
         $this->message = $this->createMock(Message::class);


### PR DESCRIPTION
## Description

- Fix `AntidotTest\Queue\Container;` namespace for `LoggerExtensionFactoryTest` class.
- Using the `assertSame` to replace `assertEquals` and it can make equal assertions strict.
- According to the [PHPUnit fixtures](https://phpunit.readthedocs.io/en/9.3/fixtures.html#more-setup-than-teardown), it should be `protected function setUp(): void`.

## Motivation and context

- It's about improvements.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Improvements.

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [X] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [X] My pull request addresses exactly one patch/feature.
- [X] I have created a branch for this patch/feature.
- [X] Each individual commit in the pull request is meaningful.
- [X] I have added tests to cover my changes.
- [X] If my change requires a change to the documentation, I have updated it accordingly.
