### PR TITLE
Add Composer plugin dependnecies to allow_plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,11 @@
         "test": "phpunit --colors=always"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "infection/extension-installer": true,
+            "phpro/grumphp": true
+        }
     },
     "extra": {
         "laminas": {


### PR DESCRIPTION
## Description

Add the `allow_plugin` setting for some dependencies.

## Motivation and context

It can avoid following exception messages when running the `composer update` command:

```
                                                                               
  phpro/grumphp contains a Composer plugin which is blocked b  
  y your allow-plugins config. You may add it to the list if you consider it   
  safe.                                                                        
  You can run "composer config --no-plugins allow-plugins.infection/extension  
  -installer [true|false]" to enable it (true) or disable it explicitly and s  
  uppress this exception (false)                                               
  See https://getcomposer.org/allow-plugins
```

```
  infection/extension-installer contains a Composer plugin which is blocked b  
  y your allow-plugins config. You may add it to the list if you consider it   
  safe.                                                                        
  You can run "composer config --no-plugins allow-plugins.infection/extension  
  -installer [true|false]" to enable it (true) or disable it explicitly and s  
  uppress this exception (false)                                               
  See https://getcomposer.org/allow-plugins 
```

## How has this been tested?

N/A

## Screenshots (if appropriate)

N/A

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Improve Composer setting.

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [X] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [X] My pull request addresses exactly one patch/feature.
- [X] I have created a branch for this patch/feature.
- [X] Each individual commit in the pull request is meaningful.
- [X] I have added tests to cover my changes.
- [X] If my change requires a change to the documentation, I have updated it accordingly.
